### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [
-            8.1
-            8.2
-        ]
+        php:
+          - '8.1'
+          - '8.2'
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -47,7 +46,6 @@ jobs:
       - name: Install dependencies
         run: |
           composer update --prefer-dist --no-interaction
-
           composer dump-autoload -o
 
       - name: Run tests


### PR DESCRIPTION
There was a YAML syntax error resulting in only **one** run.
Called `tests (8.1 8.2)`